### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,7 +11,7 @@
 	<dependency id="cordova-plugin-file-transfer" version="0.4.8" />
 	<dependency id="cordova-plugin-network-information" version="0.2.14" />
 	<dependency id="cordova-plugin-zip" version="2.1.0" />
-	<dependency id="de.fastr.phonegap.plugins.md5chksum" version="0.1.3" />	
+	<dependency id="cordova-plugin-fastrde-md5" version="0.1.3" />	
 
 	<js-module src="www/downloader.min.js" name="downloader">
 		<clobbers target="downloader" />


### PR DESCRIPTION
Fix: Notice: de.fastr.phonegap.plugins.md5chksum has been automatically converted to  cordova-plugin-fastrde-md5 and fetched from npm. This is due to our old plugins registry shutting down.
